### PR TITLE
#3 add option to ignore some events on idle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Or load it from unpkg:
 ```
 
 ## How to use
+
 ### Basic example
+
 ```javascript
 import createActivityDetector from 'activity-detector';
 
@@ -31,13 +33,16 @@ activityDetector.on('active', () => {
 	console.log('The user is using the page');
 });
 ```
+
 ### Advanced options
+
 Activity detector allows you to configure some parameters:
-- ```timeToIdle```: number of milliseconds of inactivity which makes activity detector transition to 'idle' (```30000``` by default),
-- ```activityEvents```: the user events which make activity detector transition from 'idle' to 'active'. The default list of activityEvents is ```['click', 'mousemove', 'keydown', 'DOMMouseScroll', 'mousewheel', 'mousedown', 'touchstart', 'touchmove', 'focus']```
-- ```inactivityEvents```: the list of events which make the activity detector transition from 'active' to 'idle' without waiting for ```timeToIdle``` timeout. By default: ```['blur']```
-- ```initialState```: can be ```"idle"``` or ```"active"``` (```"active"``` by default),
-- ```autoInit```: when ```true``` the activity detector starts just after creation, when ```false```, it doesn't start until you call the ```.init()``` method (```true``` by default),
+- `timeToIdle`: number of milliseconds of inactivity which makes activity detector transition to 'idle' (`30000` by default)
+- `activityEvents`: the user events which make activity detector transition from 'idle' to 'active'. The default list of activityEvents is `['click', 'mousemove', 'keydown', 'DOMMouseScroll', 'mousewheel', 'mousedown', 'touchstart', 'touchmove', 'focus']`
+- `inactivityEvents`: the list of events which make the activity detector transition from 'active' to 'idle' without waiting for `timeToIdle` timeout. By default: `['blur']`
+- `ignoredEventsWhenIdle`: list of events to ignore in idle state. By default: `['mousemove']`
+- `initialState`: can be `"idle"` or `"active"` (`"active"` by default)
+- `autoInit`: when `true` the activity detector starts just after creation, when `false`, it doesn't start until you call the `.init()` method (`true` by default)
 
 For example:
 ```javascript
@@ -57,25 +62,31 @@ activityDetector.init();
 ```
 
 ### Instance methods
+
 An activity detector instance has the following methods:
 
-#### ```start(initialState = 'active')```
-Initializes the activity detector in the given state. This method should only be used if you created the activity detector with the ```autoInit``` option ```false```.
+#### `start(initialState = 'active')`
 
-This method receives the ```initialState``` param. It can be ```'idle'``` or ```'active'``` (default)
+Initializes the activity detector in the given state. This method should only be used if you created the activity detector with the `autoInit` option `false`.
 
-#### ```on(event, handler)```
+This method receives the `initialState` param. It can be `'idle'` or `'active'` (default)
+
+#### `on(event, handler)`
+
 Registers an event listener for the required event
 
-```event``` can be ```'idle'``` or ```'active'```.
+`event` can be `'idle'` or `'active'`.
 
-```handler``` must be a function.
+`handler` must be a function.
 
-#### ```stop()```
+#### `stop()`
+
 Stops the activity detector and cleans the listeners.
 
 ## Development
+
 ### Run tests
+
 ```
 $ npm install
 $ npm test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint src/ tests/",
     "build": "babel -d dist/ src/",
     "build:umd": "webpack -p src/activity-detector.js dist/activity-detector.min.js",
-    "clean": "rm -r node_modules dist",
+    "clean": "rimraf dist",
     "prepublish": "npm run lint && npm test && npm run clean && npm run build && npm run build:umd"
   },
   "repository": {
@@ -37,6 +37,7 @@
     "eslint": "^2.2.0",
     "faucet": "0.0.1",
     "jsdom": "8.0.4",
+    "rimraf": "^2.5.4",
     "sinon": "^1.17.3",
     "tape": "^4.4.0",
     "webpack": "^1.12.14"

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "Detects when a user is really using your page and when he is idle",
   "main": "dist/activity-detector.js",
   "scripts": {
-    "test": "npm run lint && ./node_modules/.bin/tape -r babel-register 'tests/**/*.js' | ./node_modules/.bin/faucet",
-    "lint": "./node_modules/.bin/eslint src/ tests/",
-    "build": "./node_modules/.bin/babel -d dist/ src/",
-    "build:umd": "./node_modules/.bin/webpack -p src/activity-detector.js dist/activity-detector.min.js",
+    "test": "tape -r babel-register 'tests/**/*.js' | faucet",
+    "lint": "eslint src/ tests/",
+    "build": "babel -d dist/ src/",
+    "build:umd": "webpack -p src/activity-detector.js dist/activity-detector.min.js",
     "clean": "rm -r node_modules dist",
-    "prepublish": "npm run build; npm run build:umd"
+    "prepublish": "npm run lint && npm test && npm run clean && npm run build && npm run build:umd"
   },
   "repository": {
     "type": "git",

--- a/src/activity-detector.js
+++ b/src/activity-detector.js
@@ -77,7 +77,7 @@ const activityDetector = ({
         }
     };
 
-    const handleUserInactivityEvent = (event) => {
+    const handleUserInactivityEvent = () => {
         setState(IDLE);
     };
 


### PR DESCRIPTION
Added a new constructor option: `ignoredEventsWhenIdle` (defaults to `['mousemove']`)

Additional changes:
- Synchronous execution of event handlers
- Removed `.find()` usage

I recommend to release a major version after applying these changes