### PR TITLE
Make visibilitychange event optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - '5'
   - '4'
+  - '8'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Detects when a user is really using your page and when he is idle",
   "main": "dist/activity-detector.js",
   "scripts": {
-    "test": "tape -r babel-register 'tests/**/*.js' | faucet",
+    "test": "tape -r babel-register tests/**/*.js | faucet",
     "lint": "eslint src/ tests/",
     "build": "babel -d dist/ src/",
     "build:umd": "webpack -p src/activity-detector.js dist/activity-detector.min.js",

--- a/src/activity-detector.js
+++ b/src/activity-detector.js
@@ -15,7 +15,7 @@ const DEFAULT_ACTIVITY_EVENTS = [
     'focus',
 ];
 
-const DEFAULT_INACTIVITY_EVENTS = ['blur'];
+const DEFAULT_INACTIVITY_EVENTS = ['blur', 'visibilitychange'];
 
 const DEFAULT_IGNORED_EVENTS_WHEN_IDLE = ['mousemove'];
 
@@ -94,10 +94,11 @@ const activityDetector = ({
         activityEvents.forEach(eventName =>
             window.addEventListener(eventName, handleUserActivityEvent));
 
-        inactivityEvents.forEach(eventName =>
-            window.addEventListener(eventName, handleUserInactivityEvent));
+        inactivityEvents.filter(eventName => eventName !== 'visibilitychange')
+            .forEach(eventName =>
+                window.addEventListener(eventName, handleUserInactivityEvent));
 
-        if (visibilityChangeEvent) {
+        if (inactivityEvents.includes('visibilitychange') && visibilityChangeEvent) {
             document.addEventListener(visibilityChangeEvent, handleVisibilityChangeEvent);
         }
     };

--- a/src/activity-detector.js
+++ b/src/activity-detector.js
@@ -98,7 +98,7 @@ const activityDetector = ({
             .forEach(eventName =>
                 window.addEventListener(eventName, handleUserInactivityEvent));
 
-        if (inactivityEvents.includes('visibilitychange') && visibilityChangeEvent) {
+        if (inactivityEvents.indexOf('visibilitychange') >= 0 && visibilityChangeEvent) {
             document.addEventListener(visibilityChangeEvent, handleVisibilityChangeEvent);
         }
     };

--- a/tests/activity-detector-test.js
+++ b/tests/activity-detector-test.js
@@ -193,6 +193,10 @@ test('Activity detector ignores some events on idle', t => {
     fireWinEvent('click');
     t.true(isActive);
 
+    document.hidden = true;
+    fireDocEvent('visibilitychange');
+    t.true(isActive);
+
     activityDetector.stop();
     t.end();
 });


### PR DESCRIPTION
WHen the user goes to another browser tab, the document changes to `hidden`, so treated as `IDLE`. WIth this change, we can just skip that `visibilitychange` in the `inactivityEvents`.